### PR TITLE
feat(compiler): Bundle scripts into standalone executables with `buzz compile` (stage 1 of #302)

### DIFF
--- a/src/Bundle.zig
+++ b/src/Bundle.zig
@@ -1,0 +1,195 @@
+//! Stage 1 of the AOT story (see issue #302): a "bundler".
+//!
+//! Instead of emitting native code, `buzz compile` produces a standalone
+//! executable by copying the buzz runtime binary and appending the script
+//! to it. At startup the runtime checks whether it has a payload glued to
+//! its tail; if so it runs that instead of acting as the normal CLI.
+//!
+//! On-disk layout of a bundled executable:
+//!
+//!     [ buzz runtime binary ][ source ][ name ][ root_dir ][ Footer ]
+//!
+//! The Footer is fixed size and ends the file, so a bundled binary can locate
+//! its own payload by reading its last `footer_size` bytes. This reuses the
+//! existing parser/codegen/VM (no new codegen) and keeps buzz state, stack and
+//! GC exactly as they are when running a script normally — the executable is
+//! "runtime + program", which is what the GC needs anyway.
+//!
+//! Known limitations (intentional for a stage 1 prototype):
+//!   - The script source is embedded, not its bytecode, so the bundle still
+//!     parses/compiles at startup. Serializing compiled functions is a later
+//!     step.
+//!   - `import` of the std lib still resolves from disk (via BUZZ_PATH / the
+//!     embedded root_dir), so bundles are not yet fully self-contained.
+
+const std = @import("std");
+
+/// Identifies a buzz bundle. Bumped if the footer layout changes.
+pub const magic = "buzzbndl".*;
+pub const format_version: u32 = 1;
+
+/// magic(8) + version(4) + 6 * u64 offsets/lengths.
+pub const footer_size = 8 + 4 + 8 * 6;
+
+const Footer = struct {
+    source_offset: u64,
+    source_len: u64,
+    name_offset: u64,
+    name_len: u64,
+    root_dir_offset: u64,
+    root_dir_len: u64,
+
+    fn read(buf: *const [footer_size]u8) ?Footer {
+        if (!std.mem.eql(u8, buf[0..8], &magic)) return null;
+        if (std.mem.readInt(u32, buf[8..12], .little) != format_version) return null;
+
+        return .{
+            .source_offset = std.mem.readInt(u64, buf[12..20], .little),
+            .source_len = std.mem.readInt(u64, buf[20..28], .little),
+            .name_offset = std.mem.readInt(u64, buf[28..36], .little),
+            .name_len = std.mem.readInt(u64, buf[36..44], .little),
+            .root_dir_offset = std.mem.readInt(u64, buf[44..52], .little),
+            .root_dir_len = std.mem.readInt(u64, buf[52..60], .little),
+        };
+    }
+
+    fn write(self: Footer, buf: *[footer_size]u8) void {
+        @memcpy(buf[0..8], &magic);
+        std.mem.writeInt(u32, buf[8..12], format_version, .little);
+        std.mem.writeInt(u64, buf[12..20], self.source_offset, .little);
+        std.mem.writeInt(u64, buf[20..28], self.source_len, .little);
+        std.mem.writeInt(u64, buf[28..36], self.name_offset, .little);
+        std.mem.writeInt(u64, buf[36..44], self.name_len, .little);
+        std.mem.writeInt(u64, buf[44..52], self.root_dir_offset, .little);
+        std.mem.writeInt(u64, buf[52..60], self.root_dir_len, .little);
+    }
+};
+
+pub const Payload = struct {
+    source: []u8,
+    name: []u8,
+    root_dir: []u8,
+
+    pub fn deinit(self: Payload, allocator: std.mem.Allocator) void {
+        allocator.free(self.source);
+        allocator.free(self.name);
+        allocator.free(self.root_dir);
+    }
+};
+
+/// Absolute path of the running executable, the same primitive buzz uses to
+/// locate its std lib prefix (see `Parser.buzzPrefix`).
+fn selfExePath(allocator: std.mem.Allocator, io: std.Io) ![]u8 {
+    var buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const len = try std.process.executablePath(io, &buf);
+    return allocator.dupe(u8, buf[0..len]);
+}
+
+fn readAllAlloc(io: std.Io, file: anytype, allocator: std.mem.Allocator) ![]u8 {
+    const size = (try file.stat(io)).size;
+    const bytes = try allocator.alloc(u8, size);
+    errdefer allocator.free(bytes);
+    _ = try file.readPositionalAll(io, bytes, 0);
+    return bytes;
+}
+
+/// If the running executable has a bundle glued to its tail, return its payload.
+/// Returns null (never errors) when not a bundle, so a normal `buzz` invocation
+/// falls through to the regular CLI.
+pub fn read(allocator: std.mem.Allocator, io: std.Io) ?Payload {
+    return readImpl(allocator, io) catch null;
+}
+
+fn readImpl(allocator: std.mem.Allocator, io: std.Io) !?Payload {
+    const exe_path = try selfExePath(allocator, io);
+    defer allocator.free(exe_path);
+
+    var file = try std.Io.Dir.openFileAbsolute(io, exe_path, .{});
+    defer file.close(io);
+
+    const size = (try file.stat(io)).size;
+    if (size < footer_size) return null;
+
+    var footer_buf: [footer_size]u8 = undefined;
+    _ = try file.readPositionalAll(io, &footer_buf, size - footer_size);
+
+    const footer = Footer.read(&footer_buf) orelse return null;
+
+    const source = try allocator.alloc(u8, footer.source_len);
+    errdefer allocator.free(source);
+    _ = try file.readPositionalAll(io, source, footer.source_offset);
+
+    const name = try allocator.alloc(u8, footer.name_len);
+    errdefer allocator.free(name);
+    _ = try file.readPositionalAll(io, name, footer.name_offset);
+
+    const root_dir = try allocator.alloc(u8, footer.root_dir_len);
+    errdefer allocator.free(root_dir);
+    _ = try file.readPositionalAll(io, root_dir, footer.root_dir_offset);
+
+    return .{ .source = source, .name = name, .root_dir = root_dir };
+}
+
+/// Produce `out_path`: a copy of the running buzz binary with `script_path`
+/// (and the root dir it should resolve imports against) appended.
+pub fn write(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    script_path: []const u8,
+    out_path: []const u8,
+) !void {
+    var script_file = if (std.fs.path.isAbsolute(script_path))
+        try std.Io.Dir.openFileAbsolute(io, script_path, .{})
+    else
+        try std.Io.Dir.cwd().openFile(io, script_path, .{});
+    defer script_file.close(io);
+
+    const source = try readAllAlloc(io, script_file, allocator);
+    defer allocator.free(source);
+
+    // Resolve the script's absolute path so imports keep working the same way
+    // they would when running the script directly.
+    var abs_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const abs_len = try script_file.realPath(io, &abs_buf);
+    const name = abs_buf[0..abs_len];
+    const root_dir = std.fs.path.dirname(name) orelse ".";
+
+    const exe_path = try selfExePath(allocator, io);
+    defer allocator.free(exe_path);
+
+    var exe_file = try std.Io.Dir.openFileAbsolute(io, exe_path, .{});
+    const runtime = try readAllAlloc(io, exe_file, allocator);
+    exe_file.close(io);
+    defer allocator.free(runtime);
+
+    const source_offset = runtime.len;
+    const name_offset = source_offset + source.len;
+    const root_dir_offset = name_offset + name.len;
+
+    var footer_buf: [footer_size]u8 = undefined;
+    (Footer{
+        .source_offset = source_offset,
+        .source_len = source.len,
+        .name_offset = name_offset,
+        .name_len = name.len,
+        .root_dir_offset = root_dir_offset,
+        .root_dir_len = root_dir.len,
+    }).write(&footer_buf);
+
+    var out_file = try std.Io.Dir.cwd().createFile(io, out_path, .{ .truncate = true });
+    defer out_file.close(io);
+
+    // Make the result runnable (no-op on platforms without a unix exec bit).
+    try out_file.setPermissions(io, .executable_file);
+
+    var out_buffer: [64 * 1024]u8 = undefined;
+    var out_writer = out_file.writer(io, &out_buffer);
+    const w = &out_writer.interface;
+
+    try w.writeAll(runtime);
+    try w.writeAll(source);
+    try w.writeAll(name);
+    try w.writeAll(root_dir);
+    try w.writeAll(&footer_buf);
+    try w.flush();
+}

--- a/src/Runner.zig
+++ b/src/Runner.zig
@@ -219,6 +219,31 @@ pub fn runFile(
     return runner.vm.exit_code;
 }
 
+/// Run a program from in-memory source rather than a file on disk.
+/// Used by bundled executables (see Bundle.zig / issue #302), where the source
+/// is read from the binary's own tail. Mirrors `runFile` minus the file I/O.
+pub fn runEmbedded(
+    runner: *Runner,
+    root_dir: []const u8,
+    name: []const u8,
+    source: []const u8,
+    args: []const []const u8,
+) !u8 {
+    if (try runner.parser.parse(source, root_dir, null, name)) |ast| {
+        const ast_slice = ast.slice();
+
+        if (try runner.codegen.generate(ast_slice)) |function| {
+            try runner.vm.interpret(ast_slice, function, args);
+        } else {
+            return Parser.CompileError.Recoverable;
+        }
+    } else {
+        return Parser.CompileError.Recoverable;
+    }
+
+    return runner.vm.exit_code;
+}
+
 /// Evaluate source using the current parser and vm state and return the value produced if any
 /// Used by REPL and Debugger
 pub fn runSource(self: *Runner, source: []const u8, name: []const u8) !?Value {

--- a/src/main.zig
+++ b/src/main.zig
@@ -25,6 +25,7 @@ const io = @import("io.zig");
 const Runner = @import("Runner.zig");
 const Perf = @import("Perf.zig");
 const Package = @import("Package.zig");
+const Bundle = @import("Bundle.zig");
 
 pub export const initRepl_export = wasm_repl.initRepl;
 pub export const runLine_export = wasm_repl.runLine;
@@ -37,6 +38,7 @@ else
 const SubCommand = enum {
     @"test",
     check,
+    compile,
     fetch,
     format,
     help,
@@ -49,6 +51,7 @@ const SubCommand = enum {
 /// Top-level command descriptions shown by `buzz help`.
 const command_summaries = .{
     .check = .{ .name = "check", .description = "Parse and type-check a buzz script without running it." },
+    .compile = .{ .name = "compile", .description = "Bundle a buzz script into a standalone executable." },
     .fetch = .{ .name = "fetch", .description = "Prepare package vendor links from a manifest." },
     .format = .{ .name = "format", .description = "Format a buzz script." },
     .help = .{ .name = "help", .description = "Show global or command-specific help." },
@@ -80,6 +83,11 @@ const format_params = clap.parseParamsComptime(
     \\-L, --library <str>...  Add search path for external libraries
     \\-r, --root-dir <str>    Root dir for package resolution
     \\<str>                   Script to format
+);
+
+const compile_params = clap.parseParamsComptime(
+    \\-o, --output <str>     Path of the executable to produce (defaults to the script name without extension)
+    \\<str>                  Script to bundle
 );
 
 const run_params = clap.parseParamsComptime(
@@ -119,6 +127,13 @@ pub fn main(provided_init: Init) u8 {
         init.gpa;
     // FIXME: Use process.allocator everywhere?
     init.gpa = allocator;
+
+    // If this executable was produced by `buzz compile`, it has a script glued
+    // to its tail (see Bundle.zig / issue #302). Run that and skip the CLI.
+    if (Bundle.read(allocator, init.io)) |payload| {
+        defer payload.deinit(allocator);
+        return runBundle(init, allocator, payload);
+    }
 
     var stderr = io.stderrWriter(init.io);
     var stdout = io.stdoutWriter(init.io);
@@ -419,6 +434,23 @@ pub fn main(provided_init: Init) u8 {
                 );
             },
             .init => return initPackage(init),
+            .compile => {
+                const sub_res = clap.parseEx(
+                    clap.Help,
+                    &compile_params,
+                    clap.parsers.default,
+                    &arg_iter,
+                    .{
+                        .allocator = allocator,
+                        .diagnostic = &diag,
+                    },
+                ) catch |err| {
+                    diag.report(&stderr.interface, err) catch {};
+                    return 1;
+                };
+
+                return compileScript(init, allocator, sub_res);
+            },
             .version => {
                 _repl.printBanner(&stdout.interface, true);
 
@@ -460,6 +492,57 @@ fn initPackage(init: Init) u8 {
     };
 
     return 0;
+}
+
+fn compileScript(init: Init, allocator: std.mem.Allocator, sub_res: anytype) u8 {
+    var stderr = io.stderrWriter(init.io);
+
+    const script = sub_res.positionals[0] orelse {
+        stderr.interface.writeAll("Missing script to compile\n") catch {};
+        return 1;
+    };
+
+    // Default output name: the script's basename without its extension.
+    const output = sub_res.args.output orelse std.fs.path.stem(script);
+
+    Bundle.write(allocator, init.io, script, output) catch |err| {
+        stderr.interface.print(
+            "Could not compile `{s}`: {s}\n",
+            .{ script, @errorName(err) },
+        ) catch @panic("Could not compile script");
+        return 1;
+    };
+
+    io.print(init.io, "👨‍🚀 Wrote executable `{s}`\n", .{output});
+
+    return 0;
+}
+
+fn runBundle(init: Init, allocator: std.mem.Allocator, payload: Bundle.Payload) u8 {
+    var perf: ?Perf = if (BuildOptions.show_perf) Perf.init(init.io) else null;
+    defer if (perf) |*p| p.report();
+
+    var runner: Runner = undefined;
+    runner.init(
+        init,
+        allocator,
+        .Run,
+        null,
+        if (perf) |*p| p else null,
+    ) catch {
+        return 1;
+    };
+    defer runner.deinit();
+
+    // TODO: forward this process' argv to the script.
+    return runner.runEmbedded(
+        payload.root_dir,
+        payload.name,
+        payload.source,
+        &.{},
+    ) catch {
+        return 1;
+    };
 }
 
 fn run(
@@ -630,6 +713,25 @@ fn help(init: Init, stderr: *std.Io.Writer, subcommand_opt: ?[]const u8) u8 {
                 stderr,
                 clap.Help,
                 &fetch_params,
+                .{
+                    .description_on_new_line = false,
+                    .description_indent = 4,
+                    .spacing_between_parameters = 0,
+                },
+            ) catch return 1;
+        } else if (std.mem.eql(u8, subcommand, "compile")) {
+            clap.usage(
+                stderr,
+                clap.Help,
+                &compile_params,
+            ) catch return 1;
+
+            io.print(init.io, "\n\n", .{});
+
+            clap.help(
+                stderr,
+                clap.Help,
+                &compile_params,
                 .{
                     .description_on_new_line = false,
                     .description_indent = 4,


### PR DESCRIPTION
## What

Stage 1 of the AOT compiler proposed in #302: a `buzz compile` subcommand that produces a standalone executable for a script, without introducing a new codegen backend.

`buzz compile <script> -o <out>` copies the running runtime binary and appends `[source][name][root_dir][footer]` to its tail. At startup the binary reads its own tail; when the footer magic is present it runs the embedded script through the existing parser/codegen/VM instead of acting as the CLI. buzz state, stack and GC behave exactly as a normal run — the executable is "runtime + program", which keeps the GC working as the issue calls for.

This is deliberately the no-new-codegen step. The follow-up (stage 2) is to run the existing `Jit.zig` AST→MIR lowering ahead-of-time over the `.compilable` functions and resolve native pointers at startup, falling back to the interpreter for blacklisted nodes. The rationale for reusing MIR over LLVM is in https://github.com/buzz-language/buzz/issues/302#issuecomment-4685992836.

## Changes

- `src/Bundle.zig` (new) — footer format, `read` (detect + load an embedded payload from the running binary) and `write` (produce a bundled executable).
- `src/Runner.zig` — `runEmbedded`, a counterpart to `runFile` that runs in-memory source.
- `src/main.zig` — `compile` subcommand (+ help wiring) and a payload check at the top of `main()`.

## Testing

Built and run on macOS (aarch64) with zig 0.16.0:

```
zig build
./zig-out/bin/buzz compile examples/fizzbuzz.buzz -o /tmp/fizzbuzz
BUZZ_PATH=$PWD/zig-out /tmp/fizzbuzz   # prints the expected FizzBuzz output
```

Normal CLI paths (`version`, `run-script`, `help compile`) are unaffected — a non-bundled binary is not mistaken for a bundle.

## Known limitations (intentional for stage 1)

- **Verified on darwin / zig 0.16.0 only.** The Linux and Windows self-exe / permissions paths use `std.process.executablePath` and `File.setPermissions` but haven't been exercised.
- **Not yet self-contained:** `import "buzz:std"` still resolves from disk relative to the binary (`<exe>/../lib/buzz`), so a bundle needs `BUZZ_PATH` (or the install layout) at runtime. Embedding std — or serializing compiled bytecode rather than source — is the natural next step and folds into stage 2.
- The source is embedded, not bytecode, so the bundle still parses/compiles at startup.
- argv is not yet forwarded to the embedded script (marked with a TODO).

Opening as a draft to get a read on the direction before investing in stage 2.
