### PR TITLE
fix(vm): Enforce that `collect` runs at most once per instance

### DIFF
--- a/src/GC.zig
+++ b/src/GC.zig
@@ -486,27 +486,30 @@ fn freeObj(self: *GC, obj: *o.Obj) (std.mem.Allocator.Error || std.fmt.BufPrintE
         .ObjectInstance => {
             var obj_objectinstance = o.ObjObjectInstance.cast(obj).?;
 
-            // Calling eventual destructor method
+            // Calling eventual destructor method, unless `collect` has already
+            // run for this instance (see #338).
             if (obj_objectinstance.object) |object| {
-                if (object.type_def.resolved_type.?.Object.fields.get("collect")) |field| {
-                    if (field.method and !field.static) {
-                        if (BuildOptions.gc_debug_access) {
-                            self.debugger.?.invoking_collector = true;
-                        }
-                        buzz_api.bz_invoke(
-                            obj_objectinstance.vm,
-                            obj_objectinstance.toValue(),
-                            field.index,
-                            null,
-                            0,
-                            null,
-                        );
-                        if (BuildOptions.gc_debug_access) {
-                            self.debugger.?.invoking_collector = false;
-                        }
+                if (!obj_objectinstance.collected) {
+                    if (object.type_def.resolved_type.?.Object.fields.get("collect")) |field| {
+                        if (field.method and !field.static) {
+                            if (BuildOptions.gc_debug_access) {
+                                self.debugger.?.invoking_collector = true;
+                            }
+                            buzz_api.bz_invoke(
+                                obj_objectinstance.vm,
+                                obj_objectinstance.toValue(),
+                                field.index,
+                                null,
+                                0,
+                                null,
+                            );
+                            if (BuildOptions.gc_debug_access) {
+                                self.debugger.?.invoking_collector = false;
+                            }
 
-                        // Remove void result of the collect call
-                        _ = obj_objectinstance.vm.pop();
+                            // Remove void result of the collect call
+                            _ = obj_objectinstance.vm.pop();
+                        }
                     }
                 }
             }

--- a/src/obj.zig
+++ b/src/obj.zig
@@ -1552,6 +1552,9 @@ pub const ObjObjectInstance = struct {
     fields: []Value,
     /// VM in which the instance was created, we need this so the instance destructor can be called in the appropriate vm
     vm: *VM,
+    /// Set once the `collect` destructor has run, so the VM can enforce that it
+    /// runs at most once per instance (see #338).
+    collected: bool = false,
 
     pub fn setField(self: *Self, gc: *GC, key: usize, value: Value) !void {
         self.fields[key] = value;
@@ -1750,6 +1753,12 @@ pub const ObjObject = struct {
 
     /// To avoid counting object fields that are instance properties
     property_count: ?usize = 0,
+
+    /// Index of the instance `collect` destructor in `fields`, resolved lazily.
+    /// Stays null when the object has no `collect` method (see #338).
+    collect_method_idx: ?usize = null,
+    /// Whether `collect_method_idx` has been resolved yet.
+    collect_method_resolved: bool = false,
 
     pub fn init(allocator: Allocator, type_def: *ObjTypeDef) !Self {
         const self = Self{

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -5407,6 +5407,35 @@ pub const VM = struct {
     ) !Value {
         const method = object.fields[method_idx];
 
+        // Enforce that an object's `collect` destructor runs at most once per
+        // instance, no matter how often it is called (see #338).
+        if (!object.collect_method_resolved) {
+            object.collect_method_resolved = true;
+            if (object.type_def.resolved_type.?.Object.fields.get("collect")) |field| {
+                if (field.method and !field.static) {
+                    object.collect_method_idx = field.index;
+                }
+            }
+        }
+        if (object.collect_method_idx) |collect_idx| {
+            if (collect_idx == method_idx) {
+                const instance = self.peek(arg_count)
+                    .obj().access(obj.ObjObjectInstance, .ObjectInstance, self.gc).?;
+
+                if (instance.collected) {
+                    // Already collected: skip the call and leave the void result
+                    // a normal `collect() > void` call would have produced.
+                    const result_slot = self.current_fiber.stack_top - arg_count - 1;
+                    result_slot[0] = Value.Void;
+                    self.current_fiber.stack_top = result_slot + 1;
+
+                    return method;
+                }
+
+                instance.collected = true;
+            }
+        }
+
         if (tail_call)
             try self.tailCall(
                 method,

--- a/tests/behavior/collect.buzz
+++ b/tests/behavior/collect.buzz
@@ -1,0 +1,26 @@
+import "buzz:std";
+
+var collectCount = 0;
+
+object Resource {
+    mut fun collect() > void {
+        collectCount = collectCount + 1;
+    }
+}
+
+test "collect runs at most once per instance" {
+    collectCount = 0;
+
+    final resource = mut Resource{};
+
+    // The VM must enforce that `collect` runs only once, even when called
+    // explicitly several times.
+    resource.collect();
+    resource.collect();
+    resource.collect();
+
+    std\assert(
+        collectCount == 1,
+        message: "collect should run at most once",
+    );
+}


### PR DESCRIPTION
Closes #338.

## Problem

`collect` is an object's destructor and usually releases external resources (closing a file, freeing a handle, ...), so running it more than once is a bug. Today the only defence is for the object to keep its own `collected` flag, as the issue notes — but nothing stops user code from flipping that flag back, and it's boilerplate every resource-owning object has to repeat.

## Fix

The VM now enforces collect-once per instance:

- `ObjObjectInstance` gets an internal `collected` flag (not user-visible).
- In `invokeFromObject` — the single point every method call funnels through — the first call to an object's `collect` method marks the instance and proceeds; any later call is skipped and just leaves the `void` result it would have produced. The collect method index is resolved lazily once per object and cached, so non-collect calls only pay one extra optional-compare.
- The GC skips its own destructor call when the instance is already collected, so an explicit `collect()` followed by garbage collection never double-frees.

This covers all the ways collect can be reached twice: user-then-user, user-then-GC, and recursive calls from within collect itself.

## Design note

I made the second call a silent no-op rather than a runtime error, to match the behaviour of the `collected`-flag workaround in the issue. If you'd rather it raise, that's an easy change — happy to switch it.

## Testing

- Added `tests/behavior/collect.buzz`: calls `collect()` three times and asserts the body ran once. Fails on `main` (runs 3x), passes with this change.
- Full behaviour suite green: `Ran 797, Ok: 797, Failed: 0` on macOS / zig 0.16.0.
